### PR TITLE
add a 512k thread stacksize

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -59,5 +59,5 @@ class Validator(object):
                                stdout=f_null, stderr=f_null) != 0:
                 raise JavaNotFoundException()
 
-        return subprocess.call(['java', '-Xss512k', -jar', self.vnu_jar_location] +
+        return subprocess.call(['java', '-Xss512k', '-jar', self.vnu_jar_location] +
                                opts + files)


### PR DESCRIPTION
I am getting the following error:

```
C:\workspace\temp>html5validator --show-warnings --root _site
Found files to validate: 37
StackOverflowError while evaluating HTML schema.
The checker requires a java thread stack size of at least 512k.
Consider invoking java with the -Xss option. For example:

  java -Xss512k -jar ~/vnu.jar FILE.html
```

adding the minimum thread stack size to the command resolves the problem.
