### PR TITLE
Order java cli arguments in validate

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -78,11 +78,11 @@ class Validator(object):
         return files
 
     def validate(self, files=None, errors_only=True, stack_size=None):
-        opts = []
+        vnu_opts, java_opts = [], []
         if errors_only:
-            opts.append('--errors-only')
+            vnu_opts.append('--errors-only')
         if stack_size:
-            opts.append('-Xss{}k'.format(stack_size))
+            java_opts.append('-Xss{}k'.format(stack_size))
         if not files:
             files = self.all_files()
 
@@ -96,7 +96,8 @@ class Validator(object):
 
         try:
             o = subprocess.check_output(
-                ['java', '-jar', self.vnu_jar_location] + opts + files,
+                ['java'] + java_opts +
+                ['-jar', self.vnu_jar_location] + vnu_opts + files,
                 stderr=subprocess.STDOUT,
             ).decode('utf-8')
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Hi, I got an error using html5validator on Windows regarding the threads stack size, and solved it changing the order of the elements in the subprocess call inside the Validator's validate method
(fundamentally, I had to put the "-Xss" option right after "java" and before the "-jar").