### PR TITLE
Fix #86

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import fnmatch
 import logging
 import os
+import errno
 import re
 import subprocess
 import sys
@@ -151,7 +152,7 @@ class Validator(object):
             )
             stdout, stderr = p.communicate()
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
+            if e.errno == errno.ENOENT:
                 raise JavaNotFoundException()
             else:
                 raise

--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -3,10 +3,10 @@
 
 from __future__ import unicode_literals
 
+import errno
 import fnmatch
 import logging
 import os
-import errno
 import re
 import subprocess
 import sys


### PR DESCRIPTION
This PR fixes #86.

Since Python 3.7, `os.errno` is no longer available.