### PR TITLE
Rewrite Python 2 syntax to Python 3.6+

### DIFF
--- a/html5validator/cli.py
+++ b/html5validator/cli.py
@@ -5,11 +5,9 @@ Arguments that are unknown to html5validator are passed as arguments
 to `vnu.jar`.
 """
 
-from __future__ import unicode_literals
 
 from .validator import Validator, all_files
 import argparse
-from io import open
 import logging
 import sys
 import yaml
@@ -22,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 def parse_yaml(filename, starter):
     """Parses yaml config file"""
     converted_namespace = vars(starter)
-    with open(filename, "r", encoding='utf8') as yaml_file:
+    with open(filename, encoding='utf8') as yaml_file:
         yaml_contents = yaml.safe_load(yaml_file)
     LOGGER.debug(yaml_contents)
     for item in yaml_contents.keys():
@@ -138,7 +136,7 @@ vnu.jar help below.
     else:
         logging.basicConfig(level=getattr(logging, args.log),
                             handlers=[
-                            logging.FileHandler("{}.log".format(args.log_file),
+                            logging.FileHandler(f"{args.log_file}.log",
                                                 mode="w")])
 
     validator = Validator(ignore=args.ignore,
@@ -155,8 +153,8 @@ vnu.jar help below.
             directory=args.root,
             match=args.match,
             blacklist=args.blacklist)
-    LOGGER.info('Files to validate: \n  {0}'.format('\n  '.join(files)))
-    LOGGER.info('Number of files: {0}'.format(len(files)))
+    LOGGER.info('Files to validate: \n  {}'.format('\n  '.join(files)))
+    LOGGER.info(f'Number of files: {len(files)}')
 
     error_count = validator.validate(files)
     sys.exit(min(error_count, 255))

--- a/html5validator/tests/test_config.py
+++ b/html5validator/tests/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Do an integration test for config file usage."""
 
 import os
@@ -11,28 +10,28 @@ def test_config_valid():
     """Config test for valid HTML"""
     assert subprocess.call([
         'html5validator',
-        '--config={}/config_files/valid.yaml'.format(HTML_TEST_FILES)]) == 0
+        f'--config={HTML_TEST_FILES}/config_files/valid.yaml']) == 0
 
 
 def test_config_invalid():
     """Config test for invalid HTML"""
     assert subprocess.call([
         'html5validator',
-        '--config={}/config_files/invalid.yaml'.format(HTML_TEST_FILES)]) == 1
+        f'--config={HTML_TEST_FILES}/config_files/invalid.yaml']) == 1
 
 
 def test_config_skip():
     """Config test for skipping files"""
     assert subprocess.call([
         'html5validator',
-        '--config={}/config_files/skip.yaml'.format(HTML_TEST_FILES)]) == 2
+        f'--config={HTML_TEST_FILES}/config_files/skip.yaml']) == 2
 
 
 def test_config_invalid_with_css():
     """Config test for CSS and HTML"""
     assert subprocess.call([
         'html5validator',
-        '--config={}/config_files/invalid_css.yaml'.format(HTML_TEST_FILES)
+        f'--config={HTML_TEST_FILES}/config_files/invalid_css.yaml'
     ]) == 3
 
 
@@ -186,7 +185,7 @@ def test_config_extra():
     """Config test for vnu extra arguments"""
     assert subprocess.call([
         'html5validator',
-        '--config={}/config_files/extra.yaml'.format(HTML_TEST_FILES)]) == 0
+        f'--config={HTML_TEST_FILES}/config_files/extra.yaml']) == 0
 
 
 if __name__ == '__main__':

--- a/html5validator/tests/test_simple.py
+++ b/html5validator/tests/test_simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Do an integration test. Only use simple html files."""
 
 import json
@@ -11,20 +10,20 @@ HTML_TEST_FILES = os.path.abspath(os.path.dirname(__file__))
 def test_valid():
     """Command line test for valid files"""
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES)]) == 0
+                            f'--root={HTML_TEST_FILES}/valid/']) == 0
 
 
 def test_invalid():
     """Command line test for invalid files"""
     assert subprocess.call(['html5validator',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES)]) == 1
+                            f'--root={HTML_TEST_FILES}/invalid/']) == 1
 
 
 def test_invalid_with_css():
     """Command line test for invalid CSS and HTML"""
     assert subprocess.call([
         'html5validator',
-        '--root={}/invalid/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/invalid/',
         '--also-check-css',
     ]) == 2
 
@@ -33,7 +32,7 @@ def test_invalid_css_only():
     """Command line test for invalid CSS only"""
     assert subprocess.call([
         'html5validator',
-        '--root', '{}/invalid/'.format(HTML_TEST_FILES),
+        '--root', f'{HTML_TEST_FILES}/invalid/',
         '--skip-non-css',
     ]) == 1
 
@@ -42,33 +41,33 @@ def test_invalid_single_file():
     """Command line test for invalid single file"""
     assert subprocess.call([
         'html5validator',
-        '{}/invalid/index.html'.format(HTML_TEST_FILES),
+        f'{HTML_TEST_FILES}/invalid/index.html',
     ]) == 1
 
 
 def test_warning():
     """Command line test for warnings"""
     assert subprocess.call(['html5validator',
-                            '--root={}/warning/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/warning/',
                             '--show-warnings']) == 1
 
 
 def test_warning_but_pass():
     """Command line test for passing warnings"""
     assert subprocess.call(['html5validator',
-                            '--root={}/warning/'.format(HTML_TEST_FILES)]) == 0
+                            f'--root={HTML_TEST_FILES}/warning/']) == 0
 
 
 def test_return_value():
     """Command line test for error code return value"""
     assert subprocess.call(['html5validator',
-                            '--root={}/return_value/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/return_value/',
                             '--match=254.html']) == 254
     assert subprocess.call(['html5validator',
-                            '--root={}/return_value/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/return_value/',
                             '--match=255.html']) == 255
     assert subprocess.call(['html5validator',
-                            '--root={}/return_value/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/return_value/',
                             '--match=256.html']) == 255
 
 
@@ -76,7 +75,7 @@ def test_angularjs():
     """Command line test for angularjs"""
     assert subprocess.call([
         'html5validator',
-        '--root={}/angularjs/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/angularjs/',
         '--ignore-re=Attribute “ng-[a-z-]+” not allowed',
     ]) == 0
 
@@ -86,7 +85,7 @@ def test_angularjs_no_output_with_ignore():
 
     output = subprocess.check_output([
         'html5validator',
-        '--root={}/angularjs/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/angularjs/',
         '--ignore-re=Attribute “ng-[a-z-]+” not allowed',
     ])
     assert output == b''
@@ -96,7 +95,7 @@ def test_angularjs_normal_quotes():
     """Command line test for passing angularjs"""
     assert subprocess.call([
         'html5validator',
-        '--root={}/angularjs/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/angularjs/',
         '--ignore-re=Attribute "ng-[a-z-]+" not allowed',
     ]) == 0
 
@@ -105,7 +104,7 @@ def test_multiple_ignoreres():
     """Command line test for multiple regex ignores"""
     assert subprocess.call([
         'html5validator',
-        '--root={}/multiple_ignores/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/multiple_ignores/',
         '--ignore-re', 'Attribute “ng-[a-z-]+” not allowed',
         'Start tag seen without seeing a doctype first',
     ]) == 0
@@ -115,7 +114,7 @@ def test_ignore_and_ignorere():
     """Command line test for ignore and regex ignores"""
     assert subprocess.call([
         'html5validator',
-        '--root={}/multiple_ignores/'.format(HTML_TEST_FILES),
+        f'--root={HTML_TEST_FILES}/multiple_ignores/',
         '--ignore-re', 'Attribute “ng-[a-z-]+” not allowed',
         '--ignore', 'Start tag seen without seeing a doctype first',
     ]) == 0
@@ -124,45 +123,45 @@ def test_ignore_and_ignorere():
 def test_stack_size():
     """Command line test for stack size"""
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '-lll']) == 0
 
 
 def test_valid_format_flags():
     """Command line test for output format for valid files"""
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '--format', 'text']) == 0
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '--format', 'gnu']) == 0
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '--format', 'json']) == 0
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '--format', 'xml']) == 0
 
 
 def test_invalid_format_flags():
     """Command line test for output format for invalid files"""
     assert subprocess.call(['html5validator',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/invalid/',
                             '--format', 'text']) == 3
     assert subprocess.call(['html5validator',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/invalid/',
                             '--format', 'gnu']) == 1
     assert subprocess.call(['html5validator',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/invalid/',
                             '--format', 'json']) == 1
     assert subprocess.call(['html5validator',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/invalid/',
                             '--format', 'xml']) == 8
 
 
 def test_json_parseable():
     out = subprocess.run(['html5validator',
-                          '--root={}/invalid/'.format(HTML_TEST_FILES),
+                          f'--root={HTML_TEST_FILES}/invalid/',
                           '--format=json'], stdout=subprocess.PIPE).stdout
     assert out
     for line in out.decode('utf-8').splitlines():
@@ -173,7 +172,7 @@ def test_json_parseable():
 def test_log_file():
     """Command line test for log file"""
     assert subprocess.call(['html5validator',
-                            '--root={}/valid/'.format(HTML_TEST_FILES),
+                            f'--root={HTML_TEST_FILES}/valid/',
                             '--log-file', 'test_command_line',
                             '--log', 'DEBUG']) == 0
 
@@ -183,7 +182,7 @@ def test_skip():
     assert subprocess.call(['html5validator',
                             '--blacklist', 'index.html',
                             '--also-check-css',
-                            '--root={}/invalid/'.format(HTML_TEST_FILES)
+                            f'--root={HTML_TEST_FILES}/invalid/'
                             ]) == 1
 
 

--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 """The main validator class."""
 
-from __future__ import unicode_literals
 
 import errno
 import fnmatch
@@ -80,7 +78,7 @@ def _normalize_string(s):
     return s
 
 
-class Validator(object):
+class Validator:
 
     def __init__(self,
                  ignore=None, ignore_re=None,
@@ -120,7 +118,7 @@ class Validator(object):
         java_options = []
 
         if self.stack_size is not None:
-            java_options.append('-Xss{}k'.format(self.stack_size))
+            java_options.append(f'-Xss{self.stack_size}k')
 
         return java_options
 


### PR DESCRIPTION
I used [pyupgrade](https://github.com/asottile/pyupgrade), which makes safe syntax upgrades.