### PR TITLE
Drop support for Python 3.6 in GitHub workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
         python --version
         python -c "import html5validator; print(html5validator.__version__)"
     - name: Lint html5validator
+      if: ${{ matrix.python == '3.10' }}
       # run: pylint html5validator --disable=fixme
       run: flake8
     # - name: pycodestyle html5validator

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.6
-          - os: ubuntu-latest
             python: 3.7
           - os: ubuntu-latest
             python: 3.8


### PR DESCRIPTION
Python 3.6 is officially end-of-life and is no longer supported in GitHub workflows on `ubuntu-latest`.

I guess that this is the case since `ubuntu-latest` was updated to Ubuntu 22.04: https://github.com/actions/runner-images/issues/6399

Alternatively, if folks want to continue supporting Python 3.6 in this package, the test suite could be changed to use an older Ubuntu release.
