### PR TITLE
Force UTF-8 encoding in Java JVM

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -123,7 +123,8 @@ class Validator:
 
         if self.stack_size is not None:
             java_options.append(f'-Xss{self.stack_size}k')
-
+        # Forcing UTF-8 encoding in JVM ensures JVM errors such as file access errors to be output in UTF-8
+        java_options.append('-Dfile.encoding=UTF-8')  # Sets default encoding in JVM to UTF-8
         return java_options
 
     def _vnu_options(self) -> List[str]:


### PR DESCRIPTION
Running JVM on systems with default encoding different from UTF-8 will trigger encoding error in parsing stdout and stdout messages from vnu.jar into python. Forcing JVM to run with UTF-8 encoding ensures proper handling of stings from i.e. file access errors within the JVM execution loop.