### PR TITLE
Adding JVM default stack size

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -123,7 +123,8 @@ class Validator:
 
         if self.stack_size is not None:
             java_options.append(f'-Xss{self.stack_size}k')
-
+        # Forcing UTF-8 encoding in JVM ensures JVM errors such as file access errors to be output in UTF-8
+        java_options.append('-Dfile.encoding=UTF-8')  # Sets default encoding in JVM to UTF-8
         return java_options
 
     def _vnu_options(self) -> List[str]:

--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -123,8 +123,7 @@ class Validator:
 
         if self.stack_size is not None:
             java_options.append(f'-Xss{self.stack_size}k')
-        # Forcing UTF-8 encoding in JVM ensures JVM errors such as file access errors to be output in UTF-8
-        java_options.append('-Dfile.encoding=UTF-8')  # Sets default encoding in JVM to UTF-8
+
         return java_options
 
     def _vnu_options(self) -> List[str]:

--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -123,6 +123,9 @@ class Validator:
 
         if self.stack_size is not None:
             java_options.append(f'-Xss{self.stack_size}k')
+        else:
+            # Use sane default value for stack_size as a fallback
+            java_options.append('-Xss512k')
 
         return java_options
 


### PR DESCRIPTION
Adding a sane default, -Xss512k, for JVM stack size.