### PR TITLE
Adding sane default value to JVM stack-size.

### DIFF
--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -123,6 +123,9 @@ class Validator:
 
         if self.stack_size is not None:
             java_options.append(f'-Xss{self.stack_size}k')
+        else:
+            # Use sane default value for stack_size as a fallback
+            java_options.append('-Xss512k')
 
         return java_options
 


### PR DESCRIPTION
If no value is supplied for stack_size in the constructor it defaults to zero. This makes the JVM call break hard, indicating that a minimum stack size of 512k should be used. At least this is the situation on Windows 10
This PR adds 512k as a default value for stack size if no value is set in the call to the constructor.